### PR TITLE
Add support for Celery 4.1.0

### DIFF
--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -31,7 +31,6 @@ except ImportError:
     from queue import Queue
 
 from celery import Celery
-from celery.contrib.methods import task
 import redis
 import requests
 from contracts import contract, new_contract


### PR DESCRIPTION
Thanks for your fix! It looks like this one import isn't used by your new code, and it's incompatible with Celery 4.